### PR TITLE
Subscribe to change event as fallback

### DIFF
--- a/src/HdbDevice.cpp
+++ b/src/HdbDevice.cpp
@@ -91,13 +91,14 @@ HdbDevice::~HdbDevice()
 }
 //=============================================================================
 //=============================================================================
-HdbDevice::HdbDevice(int p, int pp, int s, int c, Tango::DeviceImpl *device)
+HdbDevice::HdbDevice(int p, int pp, int s, int c, bool ch, Tango::DeviceImpl *device)
 				:Tango::LogAdapter(device)
 {
 	this->period = p;
 	this->poller_period = pp;
 	this->stats_window = s;
 	this->check_periodic_delay = c;
+	this->subscribe_change = ch;
 	_device = device;
 #ifdef _USE_FERMI_DB_RW
 	host_rw = "";

--- a/src/HdbDevice.h
+++ b/src/HdbDevice.h
@@ -106,6 +106,7 @@ public:
 	int					poller_period;
 	int					stats_window;
 	int					check_periodic_delay;
+	bool				subscribe_change;
 	/**
 	 *	Shared data
 	 */
@@ -192,8 +193,9 @@ public:
 	 *	@param pp	 	Poller thread Period
 	 *	@param s	 	Period to compute statistics
 	 *	@param c	 	Delay before timeout on periodic events
+	 *	@param ch	 	Subscribe to change event if archive event is not used
 	 */
-	HdbDevice(int p, int pp, int s, int c, Tango::DeviceImpl *device);
+	HdbDevice(int p, int pp, int s, int c, bool ch, Tango::DeviceImpl *device);
 	~HdbDevice();
 	/**
 	 * initialize object

--- a/src/HdbEventSubscriber.cpp
+++ b/src/HdbEventSubscriber.cpp
@@ -341,6 +341,7 @@ void HdbEventSubscriber::get_device_property()
 	dev_prop.push_back(Tango::DbDatum("LibConfiguration"));
 	dev_prop.push_back(Tango::DbDatum("ContextsList"));
 	dev_prop.push_back(Tango::DbDatum("DefaultStrategy"));
+	dev_prop.push_back(Tango::DbDatum("SubscribeChangeAsFallback"));
 
 	//	is there at least one property to be read ?
 	if (dev_prop.size()>0)
@@ -442,6 +443,17 @@ void HdbEventSubscriber::get_device_property()
 		}
 		//	And try to extract DefaultStrategy value from database
 		if (dev_prop[i].is_empty()==false)	dev_prop[i]  >>  defaultStrategy;
+
+		//	Try to initialize SubscribeChangeAsFallback from class property
+		cl_prop = ds_class->get_class_property(dev_prop[++i].name);
+		if (cl_prop.is_empty()==false)	cl_prop  >>  subscribeChangeAsFallback;
+		else {
+			//	Try to initialize SubscribeChangeAsFallback from default device value
+			def_prop = ds_class->get_default_device_property(dev_prop[i].name);
+			if (def_prop.is_empty()==false)	def_prop  >>  subscribeChangeAsFallback;
+		}
+		//	And try to extract SubscribeChangeAsFallback value from database
+		if (dev_prop[i].is_empty()==false)	dev_prop[i]  >>  subscribeChangeAsFallback;
 
 	}
 

--- a/src/HdbEventSubscriber.cpp
+++ b/src/HdbEventSubscriber.cpp
@@ -231,7 +231,7 @@ void HdbEventSubscriber::init_device()
 	//	Create one event handler by HDB access device
 	INFO_STREAM << "HdbEventSubscriber id="<<omni_thread::self()->id()<<endl;
 	string	status("");
-	hdb_dev = new HdbDevice(subscribeRetryPeriod, pollingThreadPeriod, statisticsTimeWindow, checkPeriodicTimeoutDelay, this);
+	hdb_dev = new HdbDevice(subscribeRetryPeriod, pollingThreadPeriod, statisticsTimeWindow, checkPeriodicTimeoutDelay, subscribeChangeAsFallback, this);
 	uint8_t index=0;
 	for(vector<string>::iterator it = contextsList.begin(); it != contextsList.end(); it++)
 	{
@@ -327,6 +327,7 @@ void HdbEventSubscriber::get_device_property()
 
 	//	Initialize property data members
 	subscribeRetryPeriod = 60;
+	subscribeChangeAsFallback = false;
 
 	/*----- PROTECTED REGION END -----*/	//	HdbEventSubscriber::get_device_property_before
 
@@ -462,6 +463,7 @@ void HdbEventSubscriber::get_device_property()
 	//	Check device property data members init
 	//DEBUG_STREAM << "hdbAccessDevice      = " << hdbAccessDevice << endl;
 	DEBUG_STREAM << "subscribeRetryPeriod = " << subscribeRetryPeriod << endl;
+	DEBUG_STREAM << "subscribeChangeAsFallback = " << subscribeChangeAsFallback << endl;
 
 	/*----- PROTECTED REGION END -----*/	//	HdbEventSubscriber::get_device_property_after
 }

--- a/src/HdbEventSubscriber.h
+++ b/src/HdbEventSubscriber.h
@@ -117,6 +117,9 @@ public:
 	vector<string>	contextsList;
 	//	DefaultStrategy:	Default strategy to be used when not specified in the single attribute configuration
 	string	defaultStrategy;
+	//	SubscribeChangeAsFallback:	It will subscribe to change event 
+	//  if archive events are not configured
+	Tango::DevBoolean	subscribeChangeAsFallback;
 
 //	Attribute data members
 public:

--- a/src/HdbEventSubscriber.xmi
+++ b/src/HdbEventSubscriber.xmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
   <classes name="HdbEventSubscriber" pogoRevision="9.4">
-    <description description="This class is able to subscribe on archive events and store value in Historical DB" title="Tango Device Server" sourcePath="/mntdirect/_users/sjames/workspace/hdb++/hdbpp-es/src" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
+    <description description="This class is able to subscribe on archive events and store value in Historical DB" title="Tango Device Server" sourcePath="/home/srubio/src/hdbpp-es-alba/src" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
       <inheritances classname="Device_4Impl" sourcePath=""/>
       <identification contact="at elettra.eu - graziano.scalamera" author="graziano.scalamera" emailDomain="elettra.eu" classFamily="Miscellaneous" siteSpecific="" platform="Unix Like" bus="Not Applicable" manufacturer="none" reference=""/>
     </description>
@@ -41,6 +41,11 @@
       <type xsi:type="pogoDsl:StringType"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
       <DefaultPropValue>ALWAYS</DefaultPropValue>
+    </classProperties>
+    <classProperties name="SubscribeChangeAsFallback" description="It will subscribe to change event &#xA;if archive events are not configured">
+      <type xsi:type="pogoDsl:BooleanType"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <DefaultPropValue>False</DefaultPropValue>
     </classProperties>
     <deviceProperties name="SubscribeRetryPeriod" description="Subscribe event retrying period in seconds.">
       <type xsi:type="pogoDsl:IntType"/>
@@ -82,6 +87,11 @@
       <type xsi:type="pogoDsl:StringType"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
       <DefaultPropValue>ALWAYS</DefaultPropValue>
+    </deviceProperties>
+    <deviceProperties name="SubscribeChangeAsFallback" description="It will subscribe to change event &#xA;if archive events are not configured">
+      <type xsi:type="pogoDsl:BooleanType"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <DefaultPropValue>False</DefaultPropValue>
     </deviceProperties>
     <commands name="State" description="This command gets the device state (stored in its &lt;i>device_state&lt;/i> data member) and returns it to the caller." execMethod="dev_state" displayLevel="OPERATOR" polledPeriod="0">
       <argin description="none.">
@@ -533,7 +543,7 @@
     <states name="FAULT" description="All attributes faulty">
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </states>
-    <preferences docHome="./doc_html" makefileHome="/segfs/tango/cppserver/env"/>
+    <preferences docHome="./doc_html" makefileHome="/usr/share/pogo/preferences"/>
     <additionalFiles name="HdbDevice" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/HdbDevice.cpp"/>
     <additionalFiles name="PushThread" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/PushThread.cpp"/>
     <additionalFiles name="SubscribeThread" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/SubscribeThread.cpp"/>

--- a/src/HdbEventSubscriberClass.cpp
+++ b/src/HdbEventSubscriberClass.cpp
@@ -523,6 +523,7 @@ void HdbEventSubscriberClass::get_class_property()
 	cl_prop.push_back(Tango::DbDatum("LibConfiguration"));
 	cl_prop.push_back(Tango::DbDatum("ContextsList"));
 	cl_prop.push_back(Tango::DbDatum("DefaultStrategy"));
+	cl_prop.push_back(Tango::DbDatum("SubscribeChangeAsFallback"));
 	
 	//	Call database and extract values
 	if (Tango::Util::instance()->_UseDb==true)
@@ -612,6 +613,18 @@ void HdbEventSubscriberClass::get_class_property()
 		{
 			def_prop    >>  defaultStrategy;
 			cl_prop[i]  <<  defaultStrategy;
+		}
+	}
+	//	Try to extract SubscribeChangeAsFallback value
+	if (cl_prop[++i].is_empty()==false)	cl_prop[i]  >>  subscribeChangeAsFallback;
+	else
+	{
+		//	Check default value for SubscribeChangeAsFallback
+		def_prop = get_default_class_property(cl_prop[i].name);
+		if (def_prop.is_empty()==false)
+		{
+			def_prop    >>  subscribeChangeAsFallback;
+			cl_prop[i]  <<  subscribeChangeAsFallback;
 		}
 	}
 	/*----- PROTECTED REGION ID(HdbEventSubscriberClass::get_class_property_after) ENABLED START -----*/
@@ -739,6 +752,20 @@ void HdbEventSubscriberClass::set_default_property()
 	}
 	else
 		add_wiz_class_prop(prop_name, prop_desc);
+	prop_name = "SubscribeChangeAsFallback";
+	prop_desc = "It will subscribe to change event \nif archive events are not configured";
+	prop_def  = "False";
+	vect_data.clear();
+	vect_data.push_back("False");
+	if (prop_def.length()>0)
+	{
+		Tango::DbDatum	data(prop_name);
+		data << vect_data ;
+		cl_def_prop.push_back(data);
+		add_wiz_class_prop(prop_name, prop_desc,  prop_def);
+	}
+	else
+		add_wiz_class_prop(prop_name, prop_desc);
 
 	//	Set Default device Properties
 	prop_name = "SubscribeRetryPeriod";
@@ -845,6 +872,20 @@ void HdbEventSubscriberClass::set_default_property()
 	prop_def  = "ALWAYS";
 	vect_data.clear();
 	vect_data.push_back("ALWAYS");
+	if (prop_def.length()>0)
+	{
+		Tango::DbDatum	data(prop_name);
+		data << vect_data ;
+		dev_def_prop.push_back(data);
+		add_wiz_dev_prop(prop_name, prop_desc,  prop_def);
+	}
+	else
+		add_wiz_dev_prop(prop_name, prop_desc);
+	prop_name = "SubscribeChangeAsFallback";
+	prop_desc = "It will subscribe to change event \nif archive events are not configured";
+	prop_def  = "False";
+	vect_data.clear();
+	vect_data.push_back("False");
 	if (prop_def.length()>0)
 	{
 		Tango::DbDatum	data(prop_name);

--- a/src/HdbEventSubscriberClass.h
+++ b/src/HdbEventSubscriberClass.h
@@ -834,6 +834,9 @@ public:
 		vector<string>	contextsList;
 		//	DefaultStrategy:	Default strategy to be used when not specified in the single attribute configuration
 		string	defaultStrategy;
+		//	SubscribeChangeAsFallback:	It will subscribe to change event 
+		//  if archive events are not configured
+		Tango::DevBoolean	subscribeChangeAsFallback;
 	public:
 		//	write class properties data members
 		Tango::DbData	cl_prop;

--- a/src/SubscribeThread.cpp
+++ b/src/SubscribeThread.cpp
@@ -42,6 +42,7 @@ static const char *RcsId = "$Header: /home/cvsadm/cvsroot/fermi/servers/hdb++/hd
 
 
 #include <HdbDevice.h>
+#include <HdbEventSubscriber.h>
 
 
 namespace HdbEventSubscriber_ns
@@ -1313,15 +1314,15 @@ void SharedData::subscribe_events()
                 }
                 catch (Tango::DevFailed &e)
                 {
-                    if (hdb_dev->SubscribeChangeAsFallback)
+                    if ((static_cast<HdbEventSubscriber *>(hdb_dev->_device))->subscribeChangeAsFallback)
                     {
-                        INFO_STREAM <<__func__<< " sig->attr->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
+                        INFO_STREAM <<__func__<< " " << sig->name << "->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
                         Tango::Except::print_exception(e);
                         event_id = sig->attr->subscribe_event(
                                                         Tango::CHANGE_EVENT,
                                                         sig->archive_cb,
                                                         /*stateless=*/false);
-                        INFO_STREAM <<__func__<< " sig->attr->subscribe_event CHANGE_EVENT SUBSCRIBED" << endl;
+                        INFO_STREAM <<__func__<< " " << sig->name << "->subscribe_event CHANGE_EVENT SUBSCRIBED" << endl;
                     } 
                     else 
                     {

--- a/src/SubscribeThread.cpp
+++ b/src/SubscribeThread.cpp
@@ -1304,23 +1304,31 @@ void SharedData::subscribe_events()
 
 			try
 			{
-				try
-				{
-				    event_id = sig->attr->subscribe_event(
-				                                    Tango::ARCHIVE_EVENT,
-				                                    sig->archive_cb,
-				                                    /*stateless=*/false);
-				}
-				catch (Tango::DevFailed &e)
-				{
-				    INFO_STREAM <<__func__<< " sig->attr->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
-				    Tango::Except::print_exception(e);
-				    event_id = sig->attr->subscribe_event(
-				                                    Tango::CHANGE_EVENT,
-				                                    sig->archive_cb,
-				                                    /*stateless=*/false);
-				    INFO_STREAM <<__func__<< " sig->attr->subscribe_event CHANGE_EVENT SUBSCRIBED" << endl;
-				}
+                try
+                {
+                    event_id = sig->attr->subscribe_event(
+                                                    Tango::ARCHIVE_EVENT,
+                                                    sig->archive_cb,
+                                                    /*stateless=*/false);
+                }
+                catch (Tango::DevFailed &e)
+                {
+                    if (hdb_dev->SubscribeChangeAsFallback)
+                    {
+                        INFO_STREAM <<__func__<< " sig->attr->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
+                        Tango::Except::print_exception(e);
+                        event_id = sig->attr->subscribe_event(
+                                                        Tango::CHANGE_EVENT,
+                                                        sig->archive_cb,
+                                                        /*stateless=*/false);
+                        INFO_STREAM <<__func__<< " sig->attr->subscribe_event CHANGE_EVENT SUBSCRIBED" << endl;
+                    } 
+                    else 
+                    {
+                        throw(e);
+                    }
+                }
+                
 				event_conf_id = sig->attr->subscribe_event(
                                                 Tango::ATTR_CONF_EVENT,
                                                 sig->archive_cb,

--- a/src/SubscribeThread.cpp
+++ b/src/SubscribeThread.cpp
@@ -1304,14 +1304,27 @@ void SharedData::subscribe_events()
 
 			try
 			{
-				event_id = sig->attr->subscribe_event(
-												Tango::ARCHIVE_EVENT,
-												sig->archive_cb,
-												/*stateless=*/false);
+				try
+				{
+				    event_id = sig->attr->subscribe_event(
+				                                    Tango::ARCHIVE_EVENT,
+				                                    sig->archive_cb,
+				                                    /*stateless=*/false);
+				}
+				catch (Tango::DevFailed &e)
+				{
+				    INFO_STREAM <<__func__<< " sig->attr->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
+				    Tango::Except::print_exception(e);
+				    event_id = sig->attr->subscribe_event(
+				                                    Tango::CHANGE_EVENT,
+				                                    sig->archive_cb,
+				                                    /*stateless=*/false);
+				    INFO_STREAM <<__func__<< " sig->attr->subscribe_event CHANGE_EVENT SUBSCRIBED" << endl;
+				}
 				event_conf_id = sig->attr->subscribe_event(
-												Tango::ATTR_CONF_EVENT,
-												sig->archive_cb,
-												/*stateless=*/false);
+                                                Tango::ATTR_CONF_EVENT,
+                                                sig->archive_cb,
+                                                /*stateless=*/false);                
 				/*sig->evstate  = Tango::ON;
 				//sig->first  = false;	//first event already arrived at subscribe_event
 				sig->status.clear();

--- a/src/SubscribeThread.cpp
+++ b/src/SubscribeThread.cpp
@@ -1314,7 +1314,7 @@ void SharedData::subscribe_events()
 				}
 				catch (Tango::DevFailed &e)
 				{
-					if ((static_cast<HdbEventSubscriber *>(hdb_dev->_device))->subscribeChangeAsFallback)
+					if (hdb_dev->subscribe_change)
 					{
 						INFO_STREAM <<__func__<< " " << sig->name << "->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
 						Tango::Except::print_exception(e);

--- a/src/SubscribeThread.cpp
+++ b/src/SubscribeThread.cpp
@@ -1305,35 +1305,35 @@ void SharedData::subscribe_events()
 
 			try
 			{
-                try
-                {
-                    event_id = sig->attr->subscribe_event(
-                                                    Tango::ARCHIVE_EVENT,
-                                                    sig->archive_cb,
-                                                    /*stateless=*/false);
-                }
-                catch (Tango::DevFailed &e)
-                {
-                    if ((static_cast<HdbEventSubscriber *>(hdb_dev->_device))->subscribeChangeAsFallback)
-                    {
-                        INFO_STREAM <<__func__<< " " << sig->name << "->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
-                        Tango::Except::print_exception(e);
-                        event_id = sig->attr->subscribe_event(
-                                                        Tango::CHANGE_EVENT,
-                                                        sig->archive_cb,
-                                                        /*stateless=*/false);
-                        INFO_STREAM <<__func__<< " " << sig->name << "->subscribe_event CHANGE_EVENT SUBSCRIBED" << endl;
-                    } 
-                    else 
-                    {
-                        throw(e);
-                    }
-                }
+				try
+				{
+					event_id = sig->attr->subscribe_event(
+						Tango::ARCHIVE_EVENT,
+						sig->archive_cb,
+						/*stateless=*/false);
+				}
+				catch (Tango::DevFailed &e)
+				{
+					if ((static_cast<HdbEventSubscriber *>(hdb_dev->_device))->subscribeChangeAsFallback)
+					{
+						INFO_STREAM <<__func__<< " " << sig->name << "->subscribe_event EXCEPTION, try CHANGE_EVENT" << endl;
+						Tango::Except::print_exception(e);
+						event_id = sig->attr->subscribe_event(
+							Tango::CHANGE_EVENT,
+							sig->archive_cb,
+							/*stateless=*/false);
+						INFO_STREAM <<__func__<< " " << sig->name << "->subscribe_event CHANGE_EVENT SUBSCRIBED" << endl;
+					} 
+					else 
+					{
+						throw(e);
+					}
+				}
                 
 				event_conf_id = sig->attr->subscribe_event(
-                                                Tango::ATTR_CONF_EVENT,
-                                                sig->archive_cb,
-                                                /*stateless=*/false);                
+					Tango::ATTR_CONF_EVENT,
+					sig->archive_cb,
+					/*stateless=*/false);                
 				/*sig->evstate  = Tango::ON;
 				//sig->first  = false;	//first event already arrived at subscribe_event
 				sig->status.clear();


### PR DESCRIPTION
Hi,

This is the change in the code that we are using in Alba to avoid modifying our high loaded devices (>400 attributes).

The event subscriber still tries to subscribe to Archive event by default; but whenever an attribute is registered and does not provide archive event, then change event is subscribed as fallback.

We suggest to add this behavior either by default (because the behavior for already configured devices doesn't change) or controlled by a property.

But, in this second case, additional changes via pogo will be required in the code.

Sergi Rubio