### PR TITLE
Add AttributeListFile device property to optionally read/store attribute list from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * New CMake build system that can download libhdbpp when requested
 * Moved HDBCmdData source from libhdbpp project
 * Clang integration
+* AttributeListFile device property to read attribute list from file
 
 ### Changed
 

--- a/src/HdbDevice.cpp
+++ b/src/HdbDevice.cpp
@@ -115,7 +115,6 @@ HdbDevice::HdbDevice(int p, int pp, int s, int c, bool ch, const string &fn, Tan
 	}
 #endif
 	list_from_file = false;
-	list_file_error = false;
 	attribute_list_str_size = 0;
 	attribute_ok_list_str_size = 0;
 	attribute_nok_list_str_size = 0;
@@ -373,8 +372,8 @@ void HdbDevice::get_hdb_signal_list(vector<string> & list)
 		}
 		else
 		{
-			WARN_STREAM << __FUNCTION__<< ": cannot open Attribute List File '" << list_filename << "' error: '" << strerror(errno) << "'";
-			list_file_error = true;
+			list_file_error="Error opening AttributeList file: " + list_filename + " Error: " + strerror(errno);
+			WARN_STREAM << __FUNCTION__<< ": " << list_file_error;
 		}
 	}
 
@@ -488,7 +487,7 @@ auto HdbDevice::subcribing_state() -> Tango::DevState
 	if (state==Tango::ON)
 		state = shared->state();				//	If OK get signals state
 */
-	if(list_file_error)
+	if(!list_file_error.empty())
 		return Tango::FAULT;
 	Tango::DevState	evstate =  shared->state();
 	Tango::DevState	dbstate =  push_shared->state();

--- a/src/HdbDevice.cpp
+++ b/src/HdbDevice.cpp
@@ -87,7 +87,7 @@ HdbDevice::~HdbDevice()
 }
 //=============================================================================
 //=============================================================================
-HdbDevice::HdbDevice(int p, int pp, int s, int c, bool ch, string fn, Tango::DeviceImpl *device)
+HdbDevice::HdbDevice(int p, int pp, int s, int c, bool ch, const string &fn, Tango::DeviceImpl *device)
 				:Tango::LogAdapter(device)
 {
 	this->period = p;
@@ -348,8 +348,8 @@ void HdbDevice::get_hdb_signal_list(vector<string> & list)
 	if (!dev_prop[0].is_empty())
 		dev_prop[0]  >>  tmplist;
 
-	//use attribute list from file only if DeviceProperty not present, or present with one empty line
-	if((tmplist.size() == 0 || (tmplist.size() == 1 && tmplist[0].length() == 0)) && list_filename.length() > 0)
+	//use attribute list from file only if AttributeList property not present, or present with one empty line
+	if((tmplist.empty() || (tmplist.size() == 1 && tmplist[0].empty())) && !list_filename.empty())
 	{
 		string str;
 		std::ifstream in(list_filename);
@@ -357,11 +357,11 @@ void HdbDevice::get_hdb_signal_list(vector<string> & list)
 		{
 			while (std::getline(in, str))
 			{
-			    if(str.size() > 0)
+			    if(!str.empty())
 				tmplist.push_back(str);
 			}
 			in.close();
-			if(tmplist.size() > 0)
+			if(!tmplist.empty())
 				list_from_file = true;
 		}
 		else

--- a/src/HdbDevice.cpp
+++ b/src/HdbDevice.cpp
@@ -115,6 +115,7 @@ HdbDevice::HdbDevice(int p, int pp, int s, int c, bool ch, const string &fn, Tan
 	}
 #endif
 	list_from_file = false;
+	list_file_error = false;
 	attribute_list_str_size = 0;
 	attribute_ok_list_str_size = 0;
 	attribute_nok_list_str_size = 0;
@@ -373,6 +374,7 @@ void HdbDevice::get_hdb_signal_list(vector<string> & list)
 		else
 		{
 			WARN_STREAM << __FUNCTION__<< ": cannot open Attribute List File '" << list_filename << "' error: '" << strerror(errno) << "'";
+			list_file_error = true;
 		}
 	}
 
@@ -486,6 +488,8 @@ auto HdbDevice::subcribing_state() -> Tango::DevState
 	if (state==Tango::ON)
 		state = shared->state();				//	If OK get signals state
 */
+	if(list_file_error)
+		return Tango::FAULT;
 	Tango::DevState	evstate =  shared->state();
 	Tango::DevState	dbstate =  push_shared->state();
 	if(evstate == Tango::ALARM || dbstate == Tango::ALARM)

--- a/src/HdbDevice.h
+++ b/src/HdbDevice.h
@@ -96,7 +96,6 @@ class HdbDevice: public Tango::LogAdapter
 public:
 	//	Data members here
 	//-----------------------------------------
-	string				status;
 	std::unique_ptr<SubscribeThread, std::function<void(SubscribeThread*)>> thread;
 	std::unique_ptr<PushThread, std::function<void(PushThread*)>> push_thread;
 	std::unique_ptr<StatsThread, std::function<void(StatsThread*)>> stats_thread;
@@ -108,7 +107,7 @@ public:
 	int					check_periodic_delay;
 	bool				subscribe_change;
 	bool				list_from_file;
-	bool				list_file_error;
+	string				list_file_error;
 	string				list_filename;
 	/**
 	 *	Shared data

--- a/src/HdbDevice.h
+++ b/src/HdbDevice.h
@@ -107,6 +107,8 @@ public:
 	int					stats_window;
 	int					check_periodic_delay;
 	bool				subscribe_change;
+	bool				list_from_file;
+	string				list_filename;
 	/**
 	 *	Shared data
 	 */
@@ -195,7 +197,7 @@ public:
 	 *	@param c	 	Delay before timeout on periodic events
 	 *	@param ch	 	Subscribe to change event if archive event is not used
 	 */
-	HdbDevice(int p, int pp, int s, int c, bool ch, Tango::DeviceImpl *device);
+	HdbDevice(int p, int pp, int s, int c, bool ch, string fn, Tango::DeviceImpl *device);
 	~HdbDevice();
 	/**
 	 * initialize object

--- a/src/HdbDevice.h
+++ b/src/HdbDevice.h
@@ -108,6 +108,7 @@ public:
 	int					check_periodic_delay;
 	bool				subscribe_change;
 	bool				list_from_file;
+	bool				list_file_error;
 	string				list_filename;
 	/**
 	 *	Shared data

--- a/src/HdbDevice.h
+++ b/src/HdbDevice.h
@@ -197,7 +197,7 @@ public:
 	 *	@param c	 	Delay before timeout on periodic events
 	 *	@param ch	 	Subscribe to change event if archive event is not used
 	 */
-	HdbDevice(int p, int pp, int s, int c, bool ch, string fn, Tango::DeviceImpl *device);
+	HdbDevice(int p, int pp, int s, int c, bool ch, const string &fn, Tango::DeviceImpl *device);
 	~HdbDevice();
 	/**
 	 * initialize object

--- a/src/HdbEventSubscriber.cpp
+++ b/src/HdbEventSubscriber.cpp
@@ -500,6 +500,8 @@ void HdbEventSubscriber::always_executed_hook()
 
 		if (state==Tango::ON)
 			set_status("Everything is OK");
+		else if(state==Tango::FAULT)
+			set_status("Error opening AttributeList file: " + attributeListFile);
 		else
 			set_status("At least, one signal is faulty");
 	}

--- a/src/HdbEventSubscriber.cpp
+++ b/src/HdbEventSubscriber.cpp
@@ -231,7 +231,7 @@ void HdbEventSubscriber::init_device()
 	//	Create one event handler by HDB access device
 	INFO_STREAM << "HdbEventSubscriber id="<<omni_thread::self()->id()<<endl;
 	string	status("");
-	hdb_dev = new HdbDevice(subscribeRetryPeriod, pollingThreadPeriod, statisticsTimeWindow, checkPeriodicTimeoutDelay, subscribeChangeAsFallback, this);
+	hdb_dev = new HdbDevice(subscribeRetryPeriod, pollingThreadPeriod, statisticsTimeWindow, checkPeriodicTimeoutDelay, subscribeChangeAsFallback, attributeListFile, this);
 	uint8_t index=0;
 	for(vector<string>::iterator it = contextsList.begin(); it != contextsList.end(); it++)
 	{
@@ -343,6 +343,7 @@ void HdbEventSubscriber::get_device_property()
 	dev_prop.push_back(Tango::DbDatum("ContextsList"));
 	dev_prop.push_back(Tango::DbDatum("DefaultStrategy"));
 	dev_prop.push_back(Tango::DbDatum("SubscribeChangeAsFallback"));
+	dev_prop.push_back(Tango::DbDatum("AttributeListFile"));
 
 	//	is there at least one property to be read ?
 	if (dev_prop.size()>0)
@@ -455,6 +456,17 @@ void HdbEventSubscriber::get_device_property()
 		}
 		//	And try to extract SubscribeChangeAsFallback value from database
 		if (dev_prop[i].is_empty()==false)	dev_prop[i]  >>  subscribeChangeAsFallback;
+
+		//	Try to initialize AttributeListFile from class property
+		cl_prop = ds_class->get_class_property(dev_prop[++i].name);
+		if (cl_prop.is_empty()==false)	cl_prop  >>  attributeListFile;
+		else {
+			//	Try to initialize AttributeListFile from default device value
+			def_prop = ds_class->get_default_device_property(dev_prop[i].name);
+			if (def_prop.is_empty()==false)	def_prop  >>  attributeListFile;
+		}
+		//	And try to extract AttributeListFile value from database
+		if (dev_prop[i].is_empty()==false)	dev_prop[i]  >>  attributeListFile;
 
 	}
 
@@ -1161,7 +1173,7 @@ void HdbEventSubscriber::add_dynamic_attributes()
  *	Command AttributeAdd related method
  *	Description: Add a new attribute to archive in HDB.
  *
- *	@param argin Attribute name, strategy, data_type, data_format, write_type 
+ *	@param argin Attribute name, strategy, data_type, data_format, write_type
  */
 //--------------------------------------------------------
 void HdbEventSubscriber::attribute_add(const Tango::DevVarStringArray *argin)

--- a/src/HdbEventSubscriber.cpp
+++ b/src/HdbEventSubscriber.cpp
@@ -292,14 +292,13 @@ void HdbEventSubscriber::init_device()
 		status += "PushThread:\n";
 		status += e.errors[0].desc;
 	}
-	//	Check if WARNING
-	if (hdb_dev->status.length()>0)
+
+	if (!hdb_dev->list_file_error.empty())
 	{
-		status += "PushThread:\n";
-		status += hdb_dev->status;
+		set_state(Tango::FAULT);
+		set_status(hdb_dev->list_file_error);
 	}
-	//	Set state and status if something wrong
-	if (status.length()>0)
+	else if (status.length()>0)
 	{
 		set_state(Tango::ALARM);
 		set_status(status);
@@ -500,9 +499,9 @@ void HdbEventSubscriber::always_executed_hook()
 
 		if (state==Tango::ON)
 			set_status("Everything is OK");
-		else if(state==Tango::FAULT)
-			set_status("Error opening AttributeList file: " + attributeListFile);
-		else
+		else if(!hdb_dev->list_file_error.empty())
+			set_status(hdb_dev->list_file_error);
+		else if (state==Tango::ALARM)
 			set_status("At least, one signal is faulty");
 	}
 

--- a/src/HdbEventSubscriber.h
+++ b/src/HdbEventSubscriber.h
@@ -120,6 +120,8 @@ public:
 	//	SubscribeChangeAsFallback:	It will subscribe to change event 
 	//  if archive events are not configured
 	Tango::DevBoolean	subscribeChangeAsFallback;
+	//	AttributeListFile:	File with attribute list, alternative to AttributeList property
+	string	attributeListFile;
 
 //	Attribute data members
 public:
@@ -511,7 +513,7 @@ public:
 	 *	Command AttributeAdd related method
 	 *	Description: Add a new attribute to archive in HDB.
 	 *
-	 *	@param argin Attribute name, strategy, ttl
+	 *	@param argin Attribute name, strategy, data_type, data_format, write_type
 	 */
 	virtual void attribute_add(const Tango::DevVarStringArray *argin);
 	virtual bool is_AttributeAdd_allowed(const CORBA::Any &any);

--- a/src/HdbEventSubscriber.xmi
+++ b/src/HdbEventSubscriber.xmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
   <classes name="HdbEventSubscriber" pogoRevision="9.6">
-    <description description="This class is able to subscribe on archive events and store value in Historical DB" title="Tango Device Server" sourcePath="/home/leon/opt/hdbpp-es/src" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
+    <description description="This class is able to subscribe on archive events and store value in Historical DB" title="Tango Device Server" sourcePath="/home/graziano/ws/hdb++/hdbpp-es/src" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
       <inheritances classname="Device_4Impl" sourcePath=""/>
       <identification contact="at elettra.eu - graziano.scalamera" author="graziano.scalamera" emailDomain="elettra.eu" classFamily="Miscellaneous" siteSpecific="" platform="Unix Like" bus="Not Applicable" manufacturer="none" reference=""/>
     </description>
@@ -92,6 +92,10 @@
       <type xsi:type="pogoDsl:BooleanType"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
       <DefaultPropValue>False</DefaultPropValue>
+    </deviceProperties>
+    <deviceProperties name="AttributeListFile" description="File with attribute list, alternative to AttributeList property">
+      <type xsi:type="pogoDsl:StringType"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </deviceProperties>
     <commands name="State" description="This command gets the device state (stored in its &lt;i>device_state&lt;/i> data member) and returns it to the caller." execMethod="dev_state" displayLevel="OPERATOR" polledPeriod="0">
       <argin description="none.">
@@ -543,7 +547,7 @@
     <states name="FAULT" description="All attributes faulty">
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </states>
-    <preferences docHome="./doc_html" makefileHome="$(TANGO_HOME)"/>
+    <preferences docHome="./doc_html" makefileHome="/usr/local/tango-9.3.3/share/pogo/preferences"/>
     <additionalFiles name="HdbDevice" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/HdbDevice.cpp"/>
     <additionalFiles name="PushThread" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/PushThread.cpp"/>
     <additionalFiles name="SubscribeThread" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/SubscribeThread.cpp"/>

--- a/src/HdbEventSubscriberClass.cpp
+++ b/src/HdbEventSubscriberClass.cpp
@@ -895,6 +895,19 @@ void HdbEventSubscriberClass::set_default_property()
 	}
 	else
 		add_wiz_dev_prop(prop_name, prop_desc);
+	prop_name = "AttributeListFile";
+	prop_desc = "File with attribute list, alternative to AttributeList property";
+	prop_def  = "";
+	vect_data.clear();
+	if (prop_def.length()>0)
+	{
+		Tango::DbDatum	data(prop_name);
+		data << vect_data ;
+		dev_def_prop.push_back(data);
+		add_wiz_dev_prop(prop_name, prop_desc,  prop_def);
+	}
+	else
+		add_wiz_dev_prop(prop_name, prop_desc);
 }
 
 //--------------------------------------------------------
@@ -1890,7 +1903,7 @@ void HdbEventSubscriberClass::command_factory()
 	AttributeAddClass	*pAttributeAddCmd =
 		new AttributeAddClass("AttributeAdd",
 			Tango::DEVVAR_STRINGARRAY, Tango::DEV_VOID,
-			"Attribute name, strategy, ttl",
+			"Attribute name, strategy, data_type, data_format, write_type",
 			"",
 			Tango::OPERATOR);
 	command_list.push_back(pAttributeAddCmd);
@@ -2097,7 +2110,7 @@ void HdbEventSubscriberClass::erase_dynamic_attributes(const Tango::DevVarString
 
 //--------------------------------------------------------
 /**
- *	Method      : HdbEventSubscriberClass::get_attr_by_name()
+ *	Method      : HdbEventSubscriberClass::get_attr_object_by_name()
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------


### PR DESCRIPTION
If AttributeList device property is empty or not defined, it looks for attribute list from the file defined in AttributeListFile. If loading from file succeeds, it updates that file when removing or adding attributes.