### PR TITLE
AttributeAdd command working with only attribute name as argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+* In AttributeAdd command, only the attribute name is needed, if the other parameters
+  are missing, a request to the database will be done to get them.
 * Do not depend on HdbClient.h, but only AbstracDB.h
 * Small refactoring and code modernization to get rid of some clang warnings.
 * Updated README for new build system

--- a/src/HdbEventSubscriber.h
+++ b/src/HdbEventSubscriber.h
@@ -518,7 +518,11 @@ public:
 	 *	Command AttributeAdd related method
 	 *	Description: Add a new attribute to archive in HDB.
 	 *
-	 *	@param argin Attribute name, strategy, data_type, data_format, write_type
+	 *	@param argin Attribute name, strategy, data_type, data_format, write_type.
+	 *               
+	 *               Note that only attribute name is mandatory.
+	 *               If the strategy is not provided, default strategy will be used.
+	 *               If any of the 3 last arguments is not provided the database will be queried to retrieve the proper values.
 	 */
 	virtual void attribute_add(const Tango::DevVarStringArray *argin);
 	virtual bool is_AttributeAdd_allowed(const CORBA::Any &any);

--- a/src/HdbEventSubscriber.xmi
+++ b/src/HdbEventSubscriber.xmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
-  <classes name="HdbEventSubscriber" pogoRevision="9.6">
-    <description description="This class is able to subscribe on archive events and store value in Historical DB" title="Tango Device Server" sourcePath="/home/graziano/ws/hdb++/hdbpp-es/src" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
+  <classes name="HdbEventSubscriber" pogoRevision="9.7">
+    <description description="This class is able to subscribe on archive events and store value in Historical DB" title="Tango Device Server" sourcePath="/home/esrf/dlacoste/workspace/hdbpp/hdbpp-es/src" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
       <inheritances classname="Device_4Impl" sourcePath=""/>
       <identification contact="at elettra.eu - graziano.scalamera" author="graziano.scalamera" emailDomain="elettra.eu" classFamily="Miscellaneous" siteSpecific="" platform="Unix Like" bus="Not Applicable" manufacturer="none" reference=""/>
     </description>
@@ -116,7 +116,7 @@
       <status abstract="true" inherited="true" concrete="true" concreteHere="false"/>
     </commands>
     <commands name="AttributeAdd" description="Add a new attribute to archive in HDB." execMethod="attribute_add" displayLevel="OPERATOR" polledPeriod="0" isDynamic="false">
-      <argin description="Attribute name, strategy, data_type, data_format, write_type">
+      <argin description="Attribute name, strategy, data_type, data_format, write_type.&#xA;&#xA;Note that only attribute name is mandatory.&#xA;If the strategy is not provided, default strategy will be used.&#xA;If any of the 3 last arguments is not provided the database will be queried to retrieve the proper values.">
         <type xsi:type="pogoDsl:StringArrayType"/>
       </argin>
       <argout description="">
@@ -547,7 +547,7 @@
     <states name="FAULT" description="All attributes faulty">
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </states>
-    <preferences docHome="./doc_html" makefileHome="/usr/local/tango-9.3.3/share/pogo/preferences"/>
+    <preferences docHome="./doc_html" makefileHome="/segfs/tango/cppserver/env"/>
     <additionalFiles name="HdbDevice" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/HdbDevice.cpp"/>
     <additionalFiles name="PushThread" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/PushThread.cpp"/>
     <additionalFiles name="SubscribeThread" path="/mntdirect/_segfs/tango/cppserver/admin/hdbevent/SubscribeThread.cpp"/>

--- a/src/HdbEventSubscriberClass.cpp
+++ b/src/HdbEventSubscriberClass.cpp
@@ -1903,7 +1903,7 @@ void HdbEventSubscriberClass::command_factory()
 	AttributeAddClass	*pAttributeAddCmd =
 		new AttributeAddClass("AttributeAdd",
 			Tango::DEVVAR_STRINGARRAY, Tango::DEV_VOID,
-			"Attribute name, strategy, data_type, data_format, write_type",
+			"Attribute name, strategy, data_type, data_format, write_type.\n\nNote that only attribute name is mandatory.\nIf the strategy is not provided, default strategy will be used.\nIf any of the 3 last arguments is not provided the database will be queried to retrieve the proper values.",
 			"",
 			Tango::OPERATOR);
 	command_list.push_back(pAttributeAddCmd);


### PR DESCRIPTION
In case some input arguments are not provided in the attributeAdd command, do a request to the database to compute them.